### PR TITLE
Fix shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get install wine \
    tini \
    -y
 
-RUN dpkg --add-architecture i386 && apt-get update && apt-get install wine32 -y
-RUN apt-get install winbind -y
+RUN dpkg --add-architecture i386 && apt-get update
+RUN apt-get install wine32 winbind -y
 
 RUN mkdir /data
 RUN chown steam /data
@@ -28,6 +28,7 @@ RUN ./steamcmd.sh +@sSteamCmdForcePlatformType windows +login anonymous +app_upd
 
 # Not VR environment variables
 ENV V_RISING_AUTOUPDATE=true
+ENV V_RISING_SHUTDOWN_TIMEOUT=60
 
 # VR environment variables for host settings
 # https://github.com/StunlockStudios/vrising-dedicated-server-instructions/blob/master/1.0.x/INSTRUCTIONS.md

--- a/README.md
+++ b/README.md
@@ -52,14 +52,19 @@ To change game configuration, mount a volume to `/data` (see [Data location](#da
 
 ### Configuration specific to this image:
 
-| ENV                        | Default | Description                                                               |
-| -------------------------- | ------- | ------------------------------------------------------------------------- |
-| V_RISING_AUTOUPDATE        | true    | Enable auto-update of the dedicated server on container start.            |
+| ENV                       | Default | Description                                                                                                                                                                               |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| V_RISING_AUTOUPDATE       | true    | Enable auto-update of the dedicated server on container start.                                                                                                                            |
+| V_RISING_SHUTDOWN_TIMEOUT | 60      | Time in seconts to wait for the server to shutdown cleanly. Make sure your Docker daemon's shutdown timeout is set to a higher value than this. See [Shutdown timeout](#shutdown-timeout) |
+
+# Shutdown timeout
+
+The default Docker daemon container shutdown timeout (the time before it force-kills a container) might not be long enough to allow the server to stop cleanly. See `shutdown-timeout` [here](https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file). It should be set to a value greater than `V_RISING_SHUTDOWN_TIMEOUT`.
 
 # Data location
 
 The persistence data folder within the container is /data. In order to have access to the save files for an easy backup, mount a folder to /data, the save files are located in the _Saves_ subfolder and the configuration files are saved in the subfolder _Settings_.
 
-
 # adminlist.txt and banlist.txt
-The adminlist.txt and banlist.txt files are located in the _/data/Settings_ folder. In there you can add your steamid to become and admin or add a steamid to the banlist. 
+
+The adminlist.txt and banlist.txt files are located in the _/data/Settings_ folder. In there you can add your steamid to become and admin or add a steamid to the banlist.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,8 +17,4 @@ services:
       - 27016:27016/udp
       - 25575:25575/tcp
     volumes:
-      - vrising-data:/saves
-
-volumes:
-  vrising-data:
-    driver: local
+      - ./data:/data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 GAME_DIR=/home/steam/Steam/steamapps/common/VRisingDedicatedServer
 
+printMessage() {
+    echo "[vrising-docker] $1"
+}
+
 cleanUp() {
     # If the server crashed this will prevent it from starting again.
     rm /tmp/.X0-lock || 0
@@ -9,15 +13,14 @@ cleanUp() {
 
 onExit() {
     SERVER_PID=$(pgrep 'VRisingServer' | awk '{print $1}')
-    echo "Trapped shutdown signal, INT'ing server process $SERVER_PID" 
+    printMessage "Trapped shutdown signal, INT'ing server process $SERVER_PID" 
     kill -INT "$SERVER_PID"
 
-    # Wait up to 120 seconds for the process to terminate
-    TIMEOUT=120
+    # Wait up to V_RISING_SHUTDOWN_TIMEOUT seconds for the server to shutdown cleanly
+    TIMEOUT=${V_RISING_SHUTDOWN_TIMEOUT}
     while [ $TIMEOUT -gt 0 ]; do
         # Check if the process is still running
         if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-	    echo "Clean shutdown."
             break
         fi
 
@@ -25,12 +28,13 @@ onExit() {
         TIMEOUT=$((TIMEOUT - 1))
     done
     
+	printMessage "Clean shutdown."
     cleanUp
 }
 
 # Update?
 if [ "${V_RISING_AUTOUPDATE}" = "true" ]; then
-    echo "Checking for updates..."
+    printMessage "Checking for updates..."
     ./steamcmd.sh +@sSteamCmdForcePlatformType windows +login anonymous +app_update 1829350 validate +quit
 fi
 
@@ -41,4 +45,3 @@ Xvfb :0 -screen 0 1024x768x16 &
 setsid '/launch_server.sh' &
 
 wait $!
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ onExit() {
     echo "Trapped shutdown signal, INT'ing server process $SERVER_PID" 
 
     if [ -n "$SERVER_PID" ]; then
-        kill -INT "$V_RISING_PID"
+        kill -INT "$SERVER_PID"
         
         # Wait for the process to terminate
         wait "$SERVER_PID"
@@ -32,7 +32,7 @@ cd $GAME_DIR
 Xvfb :0 -screen 0 1024x768x16 &
 setsid '/launch_server.sh' &
 
-BACKGROUND_PID=$!
+BACKGROUND_PID=$(pgrep 'VRisingServer' | awk '{print $1}')
 
 # Print the server process ID
 echo "Server running, PID: $BACKGROUND_PID"


### PR DESCRIPTION
Fixes #2 and adds a configurable shutdown timeout. Also adds a note about Docker daemon `shutdown-timeout` to the README.